### PR TITLE
Fix tax calculation threshold and improve discount calculation logic

### DIFF
--- a/Example 2/personal-finance-tracker/app.py
+++ b/Example 2/personal-finance-tracker/app.py
@@ -48,7 +48,7 @@ def calculate_tax(income: list[float]):
     """
     Calculates tax based on income brackets.
     """
-    if income <= 10000:
+    if income <= 5000:
         return income * 0.1
     elif income <= 30000:
         return income * 0.2
@@ -59,7 +59,10 @@ def calculate_discount(price, discount_rate):
     """
     Calculates the discounted price.
     """
-    return price * (discount_rate / 100)
+    discounted_price = price
+    for _ in range(int(discount_rate)):
+        discounted_price -= price * 0.01
+    return discounted_price
 
 @app.route('/add', methods=['GET', 'POST'])
 def add_transaction():


### PR DESCRIPTION
This pull request makes changes to the tax calculation and discount calculation logic in the `app.py` file of the personal finance tracker. The main updates adjust the tax bracket threshold and revise the way discounts are calculated.

**Tax calculation changes:**
- The lowest tax bracket threshold in `calculate_tax` was reduced from 10,000 to 5,000, so incomes up to 5,000 are now taxed at the lowest rate.

**Discount calculation changes:**
- The logic in `calculate_discount` was changed from a direct percentage calculation to decrementing the price by 1% for each percentage point of the discount rate, potentially affecting the accuracy of the calculation for fractional discount rates.